### PR TITLE
Update Java/DocuSignSample/readme.txt

### DIFF
--- a/Java/DocuSignSample/readme.txt
+++ b/Java/DocuSignSample/readme.txt
@@ -31,7 +31,7 @@ To build:
    On Linux, Unix or Mac OS X it would look like this:
             cxf.dir=/opt/apache-cxf/lib
    On Windows it could be:
-            cxf.dir=c:\dev\apache-cxf\lib
+            cxf.dir=c:/dev/apache-cxf/lib
 
 2. Optionally set elements in src/config.properties file by modifying the
    following lines eliminating the square brackets:


### PR DESCRIPTION
Ant will not treat properly as absolute path.  
Ant (even on Windows) expects forward slashes as path separator.
